### PR TITLE
Use Alpine as base for final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN cd $WORKPATH && dep ensure -v
 RUN cd $WORKPATH && make build
 
-FROM golang:alpine
+FROM alpine
 COPY --from=builder /go/src/github.com/jordyv/wait-for/dist/wait-for /usr/local/bin/wait-for
 ENTRYPOINT [ "/usr/local/bin/wait-for" ]
 CMD [ "help" ]


### PR DESCRIPTION
The `alpine` image is much smaller and works just as well with the static binary.